### PR TITLE
Fix Task model string representation and tests

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -6,5 +6,5 @@ class Task(models.Model):
     description = models.TextField()
     completed = models.BooleanField(default=False)
 
-    def _str_(self):
+    def __str__(self):
         return self.title

--- a/backend/api/tests/test_models.py
+++ b/backend/api/tests/test_models.py
@@ -1,0 +1,10 @@
+import pytest
+
+from api.models import Task
+
+
+@pytest.mark.django_db
+def test_task_str_returns_title():
+    task = Task.objects.create(title='Test task', description='Sample description')
+
+    assert str(task) == 'Test task'

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = backend.settings
+python_files = tests.py test_*.py *_tests.py

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,5 @@
 Django==3.2.3
 djangorestframework==3.12.4
 django-cors-headers==3.13.0
+pytest==8.3.3
+pytest-django==4.9.0


### PR DESCRIPTION
## Summary
- correct the Task model's `__str__` implementation
- add pytest-django configuration and dependencies
- cover the string representation with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc1af2248832ea6a1426988b5fbb1